### PR TITLE
FPSCharacter: Use of deprecated bTraceAsyncScene

### DIFF
--- a/Source/ue4_inventory_system/Public/FPSCharacter.h
+++ b/Source/ue4_inventory_system/Public/FPSCharacter.h
@@ -33,6 +33,10 @@ protected:
 	void MoveRight(float Val);
 	void PickupItem();
 	void ToggleInventory();
+
+	/* Executed on completion of async linetrace */
+	void PickupTraceComplete(const FTraceHandle& TraceHandle, FTraceDatum& TraceDatum);
+
 	APlayerController* PlayerController;
 
 private:
@@ -44,6 +48,9 @@ private:
 	UCustomUserWidget* RaycastInfoWidgetRef;
 	UCustomUserWidget* InventoryWidgetRef;
 	int GetFirstNonZeroedIndex(TArray<ABaseItem*> Array);
+
+	/* Function delegate for Async line trace in tick */
+	FTraceDelegate PickupTraceDelegate;
 
 public:	
 	virtual void Tick(float DeltaTime) override;

--- a/ue4_inventory_system.uproject
+++ b/ue4_inventory_system.uproject
@@ -1,6 +1,6 @@
 {
 	"FileVersion": 3,
-	"EngineAssociation": "4.21",
+	"EngineAssociation": "4.26",
 	"Category": "",
 	"Description": "",
 	"Modules": [


### PR DESCRIPTION
Use of parameter bTraceAsyncScene has been depricated since 4.21 and will no longer work.

Replaced with Asynchronous call for line trace in every tick. Once Async trace completes will call the bounded FTraceDelegate and set the value for ItemInSight